### PR TITLE
feat: 메시지 Key를 사용한 파티셔닝 프로듀서 예제 추가 (#5)

### DIFF
--- a/producers/src/main/java/com/example/kafka/ProducerAsyncWithKey.java
+++ b/producers/src/main/java/com/example/kafka/ProducerAsyncWithKey.java
@@ -1,0 +1,62 @@
+package com.example.kafka;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+
+/**
+ * If you wanna make KafkaProducer, ProducerRecord to Integer,
+ * you have to declare serializer.class with IntegerSerializer.class
+ */
+// KafkaProducer Configuration Settings
+public class ProducerAsyncWithKey {
+
+    public static final Logger logger = LoggerFactory.getLogger(ProducerAsyncWithKey.class.getName());
+
+    public static void main(String[] args) {
+
+        String topicName = "multipart-topic";
+
+        Properties props = new Properties();
+
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "192.168.56.101:9092"); // [1] bootstrap.servers | WHY server"s"? -> Cause we can use multi brokers(servers)
+        props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()); // [2] key.serializer.class
+        props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()); // [3] value.serializer.class
+
+        // Create KafkaProducer Object
+        KafkaProducer<String, String> kafkaProducer = new KafkaProducer<>(props);
+
+        for (int seq = 0; seq < 20; seq++) {
+
+            // Create ProducerRecord Object
+            ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topicName, String.valueOf(seq), "hello world" + seq);
+
+            // [2] Send KafkaProducer Message (Java Lambda)
+            kafkaProducer.send(producerRecord, (metadata, exception) -> {
+                if (exception == null) {
+                    logger.info("\n ###### record metadata received ##### \n" +
+                            "partition: " + metadata.partition() + "\n" +
+                            "offset: " + metadata.offset() + "\n" +
+                            "timestamp: " + metadata.timestamp());
+                } else {
+                    logger.error("exception error from broker" + exception.getMessage());
+                }
+            });
+        }
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        kafkaProducer.close();
+
+    }
+
+}


### PR DESCRIPTION
## 📌 개요
메시지 Key를 사용하여 다중 파티션 토픽에 데이터를 분산 저장하는 Producer 예제(ProducerAsyncWithKey)를 추가

---

## 📋 작업 내용
- ProducerAsyncWithKey.java 클래스 추가
- for 루프를 이용해 순차적인 Key를 가진 20개의 메시지 생성 및 비동기 전송 로직 구현
- Callback 함수에서 수신한 RecordMetadata를 로깅하여, 메시지가 Key의 해시 값에 따라 여러 파티션으로 분배되는 것을 확인하도록 함
- 루프 밖에서 프로듀서를 정상 종료하도록 kafkaProducer.close() 위치 수정

---

## 🔗 관련 이슈
Closes #5 

---

## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
