### PR TITLE
feat: 커스텀 파티셔너 구현 및 적용

### DIFF
--- a/producers/src/main/java/com/example/kafka/CustomPartitioner.java
+++ b/producers/src/main/java/com/example/kafka/CustomPartitioner.java
@@ -1,0 +1,65 @@
+package com.example.kafka;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.internals.StickyPartitionCache;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+
+// 피자 집 중에 특정 피자집은 대형 피자집이라서 따로 파티셔닝이 필요하다는 시나리오에 기반하여 작성
+public class CustomPartitioner implements Partitioner {
+
+    public static final Logger logger = LoggerFactory.getLogger(CustomPartitioner.class.getName());
+
+    private final StickyPartitionCache stickyPartitionCache = new StickyPartitionCache();
+
+    private String specialKeyName;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        specialKeyName = configs.get("custom.specialKey").toString();
+    }
+
+    /**
+     * byte[] keyBytes, byte[] valueBytes
+     * ㄴ Serialized된 byte code
+     */
+    @Override
+    public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+
+        List<PartitionInfo> partitionInfoList = cluster.partitionsForTopic(topic); // Cluster cluset: Broker들의 정보 -> partition들의 정보 추출
+        int numPartitions = partitionInfoList.size();   // partition 개수 추출 (5개)
+        int numSpecialPartitions = (int) (numPartitions * (0.5)); // special topic에 대해서는 5개 중에 2개의 partition 할당 (2개)
+        int partitionIndex = 0;
+
+
+        if (keyBytes == null) {
+//            return stickyPartitionCache.partition(topic, cluster);
+            throw new InvalidRecordException("key shoud not be null");
+        }
+
+        if (((String) key).equals(specialKeyName)) {
+            // (keyBytes -> valueBytes)
+            partitionIndex = Utils.toPositive(Utils.murmur2(valueBytes)) % numSpecialPartitions; // 0,1 설정
+        } else {
+            // specialKey에 대한 파티셔닝이 0,1로 설정되었기 때문에 specialKey가 아닌 Key에 대해서는 2,3,4로 설정해줘야 함
+            partitionIndex = Utils.toPositive(Utils.murmur2(keyBytes)) % (numPartitions - numSpecialPartitions) + 2;
+        }
+
+        logger.info("key:{} is sent to partition: {}", key.toString(), partitionIndex);
+
+        return partitionIndex;
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/producers/src/main/java/com/example/kafka/PizzaProducerCustomPartitioner.java
+++ b/producers/src/main/java/com/example/kafka/PizzaProducerCustomPartitioner.java
@@ -1,0 +1,120 @@
+package com.example.kafka;
+
+import com.github.javafaker.Faker;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * If you wanna make KafkaProducer, ProducerRecord to Integer,
+ * you have to declare serializer.class with IntegerSerializer.class
+ */
+// KafkaProducer Configuration Settings
+public class PizzaProducerCustomPartitioner {
+
+    public static final Logger logger = LoggerFactory.getLogger(PizzaProducerCustomPartitioner.class.getName());
+
+
+    public static void sendPizzaMessage(KafkaProducer<String, String> kafkaProducer, String topicName, int iterCount,
+                                        int interIntervalMillis, int intervalMillis, int intervalCount, Boolean sync) {
+
+        PizzaMessage pizzaMessage = new PizzaMessage();
+        int iterSeq = 0;
+
+        // seed값을 고정하여 Random 객체와 Faker 객체를 생성.
+        long seed = 2022;
+        Random random = new Random(seed);
+        Faker faker = Faker.instance(random);
+
+        while (iterSeq != iterCount) {
+            HashMap<String, String> pMessage = pizzaMessage.produce_msg(faker, random, iterSeq);
+            ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topicName, pMessage.get("key"), pMessage.get("message"));
+
+            sendMessage(kafkaProducer, producerRecord, pMessage, sync);
+
+            if ((intervalCount > 0) && (iterSeq % intervalCount == 0)) {
+                try {
+                    logger.info("###### intervalCount:" + intervalCount + " intervalMillis" + intervalMillis + "######");
+                    Thread.sleep(intervalMillis);
+                } catch (InterruptedException e) {
+                    logger.error(e.getMessage());
+                }
+            }
+
+            if (interIntervalMillis > 0) {
+                try {
+                    logger.info("interIntervalMillis: " + interIntervalMillis);
+                    Thread.sleep(interIntervalMillis);
+                } catch (InterruptedException e) {
+                    logger.error(e.getMessage());
+                }
+            }
+        }
+
+    }
+
+    // 동기, 비동기 분기처리
+    public static void sendMessage(KafkaProducer<String, String> kafkaProducer, ProducerRecord<String, String> producerRecord,
+                                   HashMap<String, String> pMessage, boolean sync) {
+
+        if (!sync) { // ASYNC (비동기)
+            kafkaProducer.send(producerRecord, (metadata, exception) -> {
+                if (exception == null) {
+                    logger.info("async message: " + pMessage.get("key") + "partition: " + metadata.partition() + "\n" +
+                            "offset: " + metadata.offset());
+                } else {
+                    logger.error("exception error from broker" + exception.getMessage());
+                }
+            });
+        } else { // SYNC (동기)
+            try {
+                RecordMetadata metadata = kafkaProducer.send(producerRecord).get();
+                logger.info("async message: " + pMessage.get("key") + "partition: " + metadata.partition() + "\n" +
+                        "offset: " + metadata.offset());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+
+    public static void main(String[] args) {
+
+        String topicName = "pizza-topic-partitioner";
+
+        Properties props = new Properties();
+
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "192.168.56.101:9092"); // [1] bootstrap.servers | WHY server"s"? -> Cause we can use multi brokers(servers)
+        props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()); // [2] key.serializer.class
+        props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()); // [3] value.serializer.class
+
+        // custom partitioner 등록
+        props.setProperty(ProducerConfig.PARTITIONER_CLASS_CONFIG, "com.example.kafka.CustomPartitioner");
+        // custom partitioner을 실행시키기 위한 특별 키 등록
+        props.setProperty("custom.specialKey", "P001");
+
+
+        // Create KafkaProducer Object
+        KafkaProducer<String, String> kafkaProducer = new KafkaProducer<>(props);
+
+        sendPizzaMessage(kafkaProducer, topicName, -1, 100,
+                0, 0, true);
+
+        kafkaProducer.close();
+
+    }
+
+}


### PR DESCRIPTION
## 📌 개요
 커스텀 파티셔너 구현 및 적용

---
## 📋 작업 내용
- 특정 메시지 키(P001)를 가진 레코드를 별도의 전용 파티션에 할당하고, 나머지 레코드는 다른 파티션 그룹으로 분리하여 처리하는 커스텀 파티셔닝 전략을 구현.
- 이를 통해 특정 비즈니스 로직에 따른 데이터 분리 및 관리가 가능
- CustomPartitioner.java: Partitioner 인터페이스를 구현한 클래스. 메시지 키가 P001인 경우 파티션 0, 1로, 그 외의 키는 파티션 2, 3, 4로 메시지를 라우팅하는 로직을 포함
- PizzaProducerCustomPartitioner.java: 새로 작성된 CustomPartitioner를 사용하도록 partitioner.class 설정을 추가한 프로듀서 클래스

---
## 🔗 관련 이슈
Closes #10 

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항
