### PR TITLE
feat: 기본 컨슈머 및 Wakeup 종료 예제 추가

### DIFF
--- a/consumers/build.gradle
+++ b/consumers/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.example'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
+    implementation 'org.apache.kafka:kafka-clients:3.1.0'
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation 'org.slf4j:slf4j-api:2.0.17'
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
+    implementation 'org.slf4j:slf4j-simple:2.0.17'
+    // https://mvnrepository.com/artifact/com.github.javafaker/javafaker
+    implementation 'com.github.javafaker:javafaker:1.0.2'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/consumers/src/main/java/com/example/ConsumerWakeup.java
+++ b/consumers/src/main/java/com/example/ConsumerWakeup.java
@@ -1,0 +1,73 @@
+package com.example;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+public class ConsumerWakeup {
+
+    public static final Logger logger = LoggerFactory.getLogger(ConsumerWakeup.class.getName());
+
+    public static void main(String[] args) {
+
+        String topicName = "simple-topic";
+
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "192.168.56.101:9092");
+        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "group_01");
+//        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+
+        // kafka consumer 객체 생성
+        KafkaConsumer<String, String> kafkaConsumer = new KafkaConsumer<>(props);
+
+        // subscribe
+        kafkaConsumer.subscribe(List.of(topicName));
+
+        // Main Thread 선언
+        Thread mainThread = Thread.currentThread();
+
+        // Runtime.getRuntime().addShutdownHook: Main Thread 종료 전 실행
+        // kafkaConsumer.wakeup(): poll 시점에 Exception 발생 용도
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                logger.info("main program starts to exit by calling wakeup");
+                kafkaConsumer.wakeup();
+
+                // Main Thread 죽을 때 같이 죽어야 해서 대기 상태로 놔야함
+                try {
+                    mainThread.join();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+
+        try {
+            while (true) {
+                ConsumerRecords<String, String> consumerRecords = kafkaConsumer.poll(Duration.ofMillis(1000));
+                for (ConsumerRecord<String, String> consumerRecord : consumerRecords) {
+                    logger.info("record key={}, record value={}, partition={}, record offset={}",
+                            consumerRecord.key(), consumerRecord.value(), consumerRecord.partition(), consumerRecord.offset());
+                }
+            }
+        } catch (WakeupException e) {
+            logger.error("wakeup exception has been called");
+        } finally {
+            logger.info("finally consumer is closing");
+            kafkaConsumer.close();
+        }
+    }
+
+}

--- a/consumers/src/main/java/com/example/SimpleConsumer.java
+++ b/consumers/src/main/java/com/example/SimpleConsumer.java
@@ -1,0 +1,46 @@
+package com.example;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+public class SimpleConsumer {
+
+    public static final Logger logger = LoggerFactory.getLogger(SimpleConsumer.class.getName());
+
+    public static void main(String[] args) {
+
+        String topicName = "simple-topic";
+
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "192.168.56.101:9092");
+        props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "group_01");
+
+        // kafka consumer 객체 생성
+        KafkaConsumer<String, String> kafkaConsumer = new KafkaConsumer<>(props);
+
+        // subscribe
+        kafkaConsumer.subscribe(List.of(topicName));
+
+        while (true) {
+            ConsumerRecords<String, String> consumerRecords = kafkaConsumer.poll(Duration.ofMillis(1000));
+            for (ConsumerRecord<String, String> consumerRecord : consumerRecords) {
+                logger.info("record key={}, record value={}, partition={}",
+                        consumerRecord.key(), consumerRecord.value(), consumerRecord.partition());
+            }
+        }
+
+//        kafkaConsumer.close();
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'KafkaProj-01'
 include 'producers'
+include 'consumers'
 


### PR DESCRIPTION
## 📌 개요
기본 컨슈머 및 안전한 종료(Wakeup) 컨슈머 예제 추가

---
## 📋 작업 내용
- Kafka Consumer의 기본적인 동작 방식과 안전한 종료 패턴을 학습할 수 있도록 두 가지 예제 코드를 추가
- SimpleConsumer는 poll()을 사용한 가장 간단한 형태의 메시지 수신 로직을 보여주며, ConsumerWakeup은 ShutdownHook과 wakeup() 메서드를 이용해 애플리케이션 종료 시 컨슈머를 정상적으로 닫고 불필요한 리밸런싱 지연을 방지하는 모범 사례를 제공
- consumers/SimpleConsumer.java: 기본적인 구독 및 폴링 루프를 포함하는 컨슈머 예제.
- consumers/ConsumerWakeup.java: WakeupException을 활용하여 안전하게 종료하는 컨슈머 예제.

---
## 🔗 관련 이슈
Closes #12 

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항
